### PR TITLE
Fixes issue with improper ZIP/DSK load

### DIFF
--- a/src/MSX.c
+++ b/src/MSX.c
@@ -3258,7 +3258,7 @@ msx_load_rom(char *FileName, int zip_format)
 			return -1;
 		}
 		
-		int16_t error = UNZ_OK;
+		error = UNZ_OK;
 		do    
 		{
 			error = unzReadCurrentFile( zipfile, read_buffer, READ_SIZE );

--- a/src/psp_menu.c
+++ b/src/psp_menu.c
@@ -505,19 +505,21 @@ psp_main_menu(void)
 			*/
 			error = 1;
 			loaded_msx = 0;
+			if (error == 1) end_menu = 1;
 		break;
 		// It's a Disk image
 		case 2:
 			error = ChangeDisk(0, DiskA);
 			loaded_msx = 0;
+			if (error == 1) end_menu = 1;
 		break;
 		case 3:
 			error = msx_load_rom(ZipFile, 1);
 			loaded_msx = 0;
+			if (error == 0) end_menu = 1;
 		break;
 	}
-
-	if (error == 1) end_menu = 1;
+	
 	
 	while (! end_menu)
 	{


### PR DESCRIPTION
My previous pull request broke support from loading ZIP files from the menu.
In addition to that, loading from DSK files did not work properly.
The reason was simple, it was simply due the return errors being different.

Btw, fMSX does autorun DSK files.